### PR TITLE
Uses statement

### DIFF
--- a/src/RamlToOpenApiConverter/Builders/IncludeNodeDeserializerBuilder.cs
+++ b/src/RamlToOpenApiConverter/Builders/IncludeNodeDeserializerBuilder.cs
@@ -17,6 +17,7 @@ namespace RamlToOpenApiConverter.Builders
             var includeNodeDeserializer = new YamlIncludeNodeDeserializer(includeNodeDeserializerOptions);
 
             return builder
+                .WithTagMapping(string.Empty, typeof(IncludeRef))
                 .WithTagMapping(Constants.IncludeTag, typeof(IncludeRef))
                 .WithNodeDeserializer(includeNodeDeserializer, s => s.OnTop())
                 .Build();

--- a/src/RamlToOpenApiConverter/Constants.cs
+++ b/src/RamlToOpenApiConverter/Constants.cs
@@ -3,5 +3,7 @@
     internal static class Constants
     {
         public const string IncludeTag = "!include";
+        public const string Is_tag = "is";
+        public const string Root_uses = "traits";
     }
 }

--- a/src/RamlToOpenApiConverter/Constants.cs
+++ b/src/RamlToOpenApiConverter/Constants.cs
@@ -3,7 +3,7 @@
     internal static class Constants
     {
         public const string IncludeTag = "!include";
-        public const string Is_tag = "is";
-        public const string Root_uses = "traits";
+        public const string IsTag = "is";
+        public const string Traits = "traits";
     }
 }

--- a/src/RamlToOpenApiConverter/Extensions/DictionaryExtensions.cs
+++ b/src/RamlToOpenApiConverter/Extensions/DictionaryExtensions.cs
@@ -5,29 +5,29 @@ namespace RamlToOpenApiConverter.Extensions
 {
     internal static class DictionaryExtensions
     {
-        public static string? Get(this IDictionary<object, object> d, object key)
+        public static string? Get(this IDictionary<object, object> source, object key)
         {
-            if (!d.ContainsKey(key))
+            if (!source.ContainsKey(key))
             {
                 return null;
             }
 
-            return d[key] as string;
+            return source[key] as string;
         }
 
-        public static T Get<T>(this IDictionary<object, object> d, object key)
+        public static T Get<T>(this IDictionary<object, object> source, object key)
         {
-            if (!d.ContainsKey(key))
+            if (!source.ContainsKey(key))
             {
                 return default!;
             }
 
-            return ChangeTypeEx<T>(d[key]);
+            return ChangeTypeEx<T>(source[key]);
         }
 
-        public static IDictionary<object, object>? GetAsDictionary(this IDictionary<object, object> d, object key)
+        public static IDictionary<object, object>? GetAsDictionary(this IDictionary<object, object> source, object key)
         {
-            if (d.TryGetValue(key, out object value))
+            if (source.TryGetValue(key, out object value))
             {
                 return value as IDictionary<object, object>;
             }
@@ -35,21 +35,21 @@ namespace RamlToOpenApiConverter.Extensions
             return null;
         }
 
-        public static void Replace(this IDictionary<object, object> d, IDictionary<object, object> c, object key)
+        public static void Replace(this IDictionary<object, object> source, IDictionary<object, object> newValue, object key)
         {
-            if (d.TryGetValue(key, out object value))
+            if (source.TryGetValue(key, out object value))
             {
-                d.Remove(key);
-                foreach (KeyValuePair<object, object> item in c)
+                source.Remove(key);
+                foreach (KeyValuePair<object, object> item in newValue)
                 {
-                    d.Add(item.Key, item.Value);
+                    source.Add(item.Key, item.Value);
                 }
             }
         }
 
-        public static ICollection<object>? GetAsCollection(this IDictionary<object, object> d, object key)
+        public static ICollection<object>? GetAsCollection(this IDictionary<object, object> source, object key)
         {
-            if (d.TryGetValue(key, out object value))
+            if (source.TryGetValue(key, out object value))
             {
                 return value as ICollection<object>;
             }
@@ -57,9 +57,9 @@ namespace RamlToOpenApiConverter.Extensions
             return null;
         }
 
-        public static string? GetAsString(this IDictionary<object, object> d, object key)
+        public static string? GetAsString(this IDictionary<object, object> source, object key)
         {
-            if (d.TryGetValue(key, out object value))
+            if (source.TryGetValue(key, out object value))
             {
                 if (value.GetType() == typeof(string))
                     return value.ToString();

--- a/src/RamlToOpenApiConverter/Extensions/DictionaryExtensions.cs
+++ b/src/RamlToOpenApiConverter/Extensions/DictionaryExtensions.cs
@@ -61,7 +61,10 @@ namespace RamlToOpenApiConverter.Extensions
         {
             if (d.TryGetValue(key, out object value))
             {
-                return value.ToString();
+                if (value.GetType() == typeof(string))
+                    return value.ToString();
+                else
+                    return null;
             }
 
             return null;

--- a/src/RamlToOpenApiConverter/Extensions/DictionaryExtensions.cs
+++ b/src/RamlToOpenApiConverter/Extensions/DictionaryExtensions.cs
@@ -35,11 +35,33 @@ namespace RamlToOpenApiConverter.Extensions
             return null;
         }
 
+        public static void Replace(this IDictionary<object, object> d, IDictionary<object, object> c, object key)
+        {
+            if (d.TryGetValue(key, out object value))
+            {
+                d.Remove(key);
+                foreach (KeyValuePair<object, object> item in c)
+                {
+                    d.Add(item.Key, item.Value);
+                }
+            }
+        }
+
         public static ICollection<object>? GetAsCollection(this IDictionary<object, object> d, object key)
         {
             if (d.TryGetValue(key, out object value))
             {
                 return value as ICollection<object>;
+            }
+
+            return null;
+        }
+
+        public static string? GetAsString(this IDictionary<object, object> d, object key)
+        {
+            if (d.TryGetValue(key, out object value))
+            {
+                return value.ToString();
             }
 
             return null;

--- a/src/RamlToOpenApiConverter/Extensions/DictionaryExtensions.cs
+++ b/src/RamlToOpenApiConverter/Extensions/DictionaryExtensions.cs
@@ -39,7 +39,9 @@ namespace RamlToOpenApiConverter.Extensions
         {
             if (source.TryGetValue(key, out object value))
             {
-                source.Remove(key);
+                if(newValue.Count > 0)
+                    source.Remove(key);
+
                 foreach (KeyValuePair<object, object> item in newValue)
                 {
                     source.Add(item.Key, item.Value);

--- a/src/RamlToOpenApiConverter/RamlConverter.Paths.cs
+++ b/src/RamlToOpenApiConverter/RamlConverter.Paths.cs
@@ -127,7 +127,7 @@ namespace RamlToOpenApiConverter
         {
             return new OpenApiOperation
             {
-                Description = values.Get("displayName"),
+                Description = values.Get("description"),
                 Parameters = MapParameters(values),
                 Responses = MapResponses(values.GetAsDictionary("responses")),
                 RequestBody = MapRequest(values.GetAsDictionary("body")),

--- a/src/RamlToOpenApiConverter/RamlConverter.Paths.cs
+++ b/src/RamlToOpenApiConverter/RamlConverter.Paths.cs
@@ -265,7 +265,7 @@ namespace RamlToOpenApiConverter
         private IDictionary<object, object> ReplaceUses(IDictionary<object, object> source, IDictionary<object, object> uses)
         {
             //replace uses in file
-            IDictionary<object, object> use_replace = new Dictionary<object, object>();
+            IDictionary<object, object> useReplace = new Dictionary<object, object>();
 
             if (uses.Count > 0)
             {
@@ -283,13 +283,13 @@ namespace RamlToOpenApiConverter
                             {
                                 if (use.Key.ToString() == path_is_separator[0].ToString())
                                 {
-                                    use_replace = ((IDictionary<object, object>)use.Value).GetAsDictionary(Constants.Traits);
+                                    useReplace = ((IDictionary<object, object>)use.Value).GetAsDictionary(Constants.Traits);
 
                                     for (int i = 1; i < path_is_separator.Count(); i++)
                                     {
-                                        use_replace = use_replace.GetAsDictionary(path_is_separator[i]);
+                                        useReplace = useReplace.GetAsDictionary(path_is_separator[i]);
                                     }
-                                    ((IDictionary<object, object>)path_value.Value).Replace(use_replace, Constants.IsTag);
+                                    ((IDictionary<object, object>)path_value.Value).Replace(useReplace, Constants.IsTag);
                                 }
                             }
                         }

--- a/src/RamlToOpenApiConverter/RamlConverter.Paths.cs
+++ b/src/RamlToOpenApiConverter/RamlConverter.Paths.cs
@@ -271,7 +271,6 @@ namespace RamlToOpenApiConverter
             {
                 foreach (var path_value in source)
                 {
-
                     var type = path_value.Value.GetType();
                     if (path_value.Value.GetType() == typeof(Dictionary<object, object>))
                     {

--- a/src/RamlToOpenApiConverter/RamlConverter.Paths.cs
+++ b/src/RamlToOpenApiConverter/RamlConverter.Paths.cs
@@ -42,7 +42,7 @@ namespace RamlToOpenApiConverter
                 foreach (var path_value in values)
                 {
 
-                    var _is_val = ((Dictionary<object, object>)path_value.Value).GetAsString(Constants.Is_tag);
+                    var _is_val = ((Dictionary<object, object>)path_value.Value).GetAsString(Constants.IsTag);
 
                     if (_is_val != null)
                     {
@@ -51,14 +51,14 @@ namespace RamlToOpenApiConverter
                         {
                             if (use.Key.ToString() == path_is_separator[0].ToString())
                             {
-                                use_replace = ((Dictionary<object, object>)use.Value).GetAsDictionary(Constants.Root_uses);
+                                use_replace = ((Dictionary<object, object>)use.Value).GetAsDictionary(Constants.Traits);
 
                                 for (int i = 1; i < path_is_separator.Count(); i++)
                                 {
                                     use_replace = use_replace.GetAsDictionary(path_is_separator[i]);
                                 }
 
-                                ((Dictionary<object, object>)path_value.Value).Replace(use_replace, Constants.Is_tag);
+                                ((Dictionary<object, object>)path_value.Value).Replace(use_replace, Constants.IsTag);
 
                             }
                         }

--- a/src/RamlToOpenApiConverter/RamlConverter.Paths.cs
+++ b/src/RamlToOpenApiConverter/RamlConverter.Paths.cs
@@ -289,18 +289,13 @@ namespace RamlToOpenApiConverter
                                     {
                                         use_replace = use_replace.GetAsDictionary(path_is_separator[i]);
                                     }
-
                                     ((IDictionary<object, object>)path_value.Value).Replace(use_replace, Constants.IsTag);
-
                                 }
                             }
-
                         }
                     }
-
                 }
             }
-
             return source;
         }
     }

--- a/src/RamlToOpenApiConverter/RamlConverter.Paths.cs
+++ b/src/RamlToOpenApiConverter/RamlConverter.Paths.cs
@@ -261,42 +261,5 @@ namespace RamlToOpenApiConverter
             operationType = OperationType.Get;
             return false;
         }
-
-        private IDictionary<object, object> ReplaceUses(IDictionary<object, object> source, IDictionary<object, object> uses)
-        {
-            //replace uses in file
-            IDictionary<object, object> useReplace = new Dictionary<object, object>();
-
-            if (uses.Count > 0)
-            {
-                foreach (var path_value in source)
-                {
-                    var type = path_value.Value.GetType();
-                    if (path_value.Value.GetType() == typeof(Dictionary<object, object>))
-                    {
-                        var _is_val = ((IDictionary<object, object>)path_value.Value).GetAsString(Constants.IsTag);
-
-                        if (_is_val != null)
-                        {
-                            var path_is_separator = _is_val.ToString().Split('.');
-                            foreach (var use in uses)
-                            {
-                                if (use.Key.ToString() == path_is_separator[0].ToString())
-                                {
-                                    useReplace = ((IDictionary<object, object>)use.Value).GetAsDictionary(Constants.Traits);
-
-                                    for (int i = 1; i < path_is_separator.Count(); i++)
-                                    {
-                                        useReplace = useReplace.GetAsDictionary(path_is_separator[i]);
-                                    }
-                                    ((IDictionary<object, object>)path_value.Value).Replace(useReplace, Constants.IsTag);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            return source;
-        }
     }
 }

--- a/src/RamlToOpenApiConverter/RamlConverter.Paths.cs
+++ b/src/RamlToOpenApiConverter/RamlConverter.Paths.cs
@@ -34,39 +34,7 @@ namespace RamlToOpenApiConverter
 
         private ICollection<(OpenApiPathItem Item, string AdjustedPath)> MapPathItems(string parent, IList<OpenApiParameter> parentParameters, IDictionary<object, object> values, IDictionary<object, object> uses)
         {
-            //replace uses in file
-            IDictionary<object, object> use_replace = new Dictionary<object, object>();
-
-            if (uses.Count > 0)
-            {
-                foreach (var path_value in values)
-                {
-
-                    var _is_val = ((Dictionary<object, object>)path_value.Value).GetAsString(Constants.IsTag);
-
-                    if (_is_val != null)
-                    {
-                        var path_is_separator = _is_val.ToString().Split('.');
-                        foreach (var use in uses)
-                        {
-                            if (use.Key.ToString() == path_is_separator[0].ToString())
-                            {
-                                use_replace = ((Dictionary<object, object>)use.Value).GetAsDictionary(Constants.Traits);
-
-                                for (int i = 1; i < path_is_separator.Count(); i++)
-                                {
-                                    use_replace = use_replace.GetAsDictionary(path_is_separator[i]);
-                                }
-
-                                ((Dictionary<object, object>)path_value.Value).Replace(use_replace, Constants.IsTag);
-
-                            }
-                        }
-
-                    }
-
-                }
-            }
+            values = ReplaceUses(values, uses);
 
             var items = new List<(OpenApiPathItem Item, string AdjustedPath)>();
 
@@ -292,6 +260,49 @@ namespace RamlToOpenApiConverter
 
             operationType = OperationType.Get;
             return false;
+        }
+
+        private IDictionary<object, object> ReplaceUses(IDictionary<object, object> source, IDictionary<object, object> uses)
+        {
+            //replace uses in file
+            IDictionary<object, object> use_replace = new Dictionary<object, object>();
+
+            if (uses.Count > 0)
+            {
+                foreach (var path_value in source)
+                {
+
+                    var type = path_value.Value.GetType();
+                    if (path_value.Value.GetType() == typeof(Dictionary<object, object>))
+                    {
+                        var _is_val = ((IDictionary<object, object>)path_value.Value).GetAsString(Constants.IsTag);
+
+                        if (_is_val != null)
+                        {
+                            var path_is_separator = _is_val.ToString().Split('.');
+                            foreach (var use in uses)
+                            {
+                                if (use.Key.ToString() == path_is_separator[0].ToString())
+                                {
+                                    use_replace = ((IDictionary<object, object>)use.Value).GetAsDictionary(Constants.Traits);
+
+                                    for (int i = 1; i < path_is_separator.Count(); i++)
+                                    {
+                                        use_replace = use_replace.GetAsDictionary(path_is_separator[i]);
+                                    }
+
+                                    ((IDictionary<object, object>)path_value.Value).Replace(use_replace, Constants.IsTag);
+
+                                }
+                            }
+
+                        }
+                    }
+
+                }
+            }
+
+            return source;
         }
     }
 }

--- a/src/RamlToOpenApiConverter/RamlConverter.cs
+++ b/src/RamlToOpenApiConverter/RamlConverter.cs
@@ -64,6 +64,7 @@ namespace RamlToOpenApiConverter
                 {
                     _uses.Add(use.Key, use.Value);
                 }
+                result.Remove("uses");
                 result = ReplaceUses(result,_uses);
             }
 

--- a/src/RamlToOpenApiConverter/RamlConverter.cs
+++ b/src/RamlToOpenApiConverter/RamlConverter.cs
@@ -13,6 +13,8 @@ namespace RamlToOpenApiConverter
     public partial class RamlConverter
     {
         private readonly IDictionary<object, object> _types = new Dictionary<object, object>();
+        private readonly IDictionary<object, object> _uses = new Dictionary<object, object>();
+
 
         private IDeserializer _deserializer = default!;
         private OpenApiDocument _doc = default!;
@@ -54,7 +56,17 @@ namespace RamlToOpenApiConverter
 
             var result = _deserializer.Deserialize<Dictionary<object, object>>(File.ReadAllText(inputPath));
 
-            // Step 1 - Get all types and schemas
+            // Step 1 - Get all uses
+            var uses = result.GetAsDictionary("uses");
+            if (uses != null)
+            {
+                foreach (var use in uses.Where(x => !_uses.ContainsKey(x.Key)))
+                {
+                    _uses.Add(use.Key, use.Value);
+                }
+            }
+
+            // Step 2 - Get all types and schemas
             var types = result.GetAsDictionary("types");
             if (types != null)
             {
@@ -72,7 +84,7 @@ namespace RamlToOpenApiConverter
                 }
             }
 
-            // Step 2 - Get Info, Servers and Components
+            // Step 3 - Get Info, Servers and Components
             _doc = new OpenApiDocument
             {
                 Info = MapInfo(result),
@@ -80,8 +92,8 @@ namespace RamlToOpenApiConverter
                 Components = MapComponents(_types)
             };
 
-            // Step 3 - Get Paths
-            _doc.Paths = MapPaths(result);
+            // Step 4 - Get Paths
+            _doc.Paths = MapPaths(result, _uses);
 
             // Check if valid
             var text = _doc.Serialize(OpenApiSpecVersion.OpenApi3_0, OpenApiFormat.Json);

--- a/src/RamlToOpenApiConverter/RamlConverter.cs
+++ b/src/RamlToOpenApiConverter/RamlConverter.cs
@@ -54,7 +54,7 @@ namespace RamlToOpenApiConverter
         {
             _deserializer = IncludeNodeDeserializerBuilder.Build(Path.GetDirectoryName(inputPath));
 
-            var result = _deserializer.Deserialize<Dictionary<object, object>>(File.ReadAllText(inputPath));
+            var result = _deserializer.Deserialize<IDictionary<object, object>>(File.ReadAllText(inputPath));
 
             // Step 1 - Get all uses
             var uses = result.GetAsDictionary("uses");
@@ -64,6 +64,7 @@ namespace RamlToOpenApiConverter
                 {
                     _uses.Add(use.Key, use.Value);
                 }
+                result = ReplaceUses(result,_uses);
             }
 
             // Step 2 - Get all types and schemas

--- a/src/RamlToOpenApiConverter/Yaml/YamlIncludeNodeDeserializer.cs
+++ b/src/RamlToOpenApiConverter/Yaml/YamlIncludeNodeDeserializer.cs
@@ -22,16 +22,20 @@ namespace RamlToOpenApiConverter.Yaml
 
         bool INodeDeserializer.Deserialize(IParser parser, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value)
         {
-            if (parser.Accept(out Scalar scalar) && scalar.Tag == Constants.IncludeTag)
+
+            if (parser.Accept(out Scalar scalar) && scalar != null)
             {
                 string fileName = scalar.Value.Replace('/', Path.DirectorySeparatorChar);
-                string includePath = Path.Combine(_options.DirectoryName, fileName);
+                var extension = Path.GetExtension(fileName);
+                string? includePath = null;
 
-                value = ReadIncludedFile(includePath, expectedType);
-
-                parser.MoveNext();
-
-                return true;
+                if (scalar.Tag == Constants.IncludeTag || (scalar.Tag != Constants.IncludeTag && (RamlExtensionRegex.IsMatch(extension) || JsonExtensionRegex.IsMatch(extension))))
+                {
+                    includePath = Path.Combine(_options.DirectoryName, fileName);
+                    value = ReadIncludedFile(includePath, expectedType);
+                    parser.MoveNext();
+                    return true;
+                }
             }
 
             value = null;

--- a/test/RamlToOpenApiConverterTest/RamlToOpenApiConverterTest.csproj
+++ b/test/RamlToOpenApiConverterTest/RamlToOpenApiConverterTest.csproj
@@ -25,6 +25,26 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="Uses.Test\" />
+    <None Remove="Uses\TestFiles\" />
+    <None Remove="Uses\TestFiles\TestExternalFiles\" />
+    <None Remove="Uses\TestFilesResult\" />
+    <None Remove="Uses\TestFiles\Test1.raml" />
+    <None Remove="Uses\TestFilesResultExpected\Test1Result.json" />
+    <None Remove="Uses\TestFiles\TestExternalFiles\common-traits.raml" />
+    <None Remove="Uses\TestFiles\Test1 %28copy%29.raml" />
+    <None Remove="Uses\TestFilesResultExpected\Test2Result.json" />
+    <None Remove="Uses\TestFiles\TestExternalFiles\common-traits3.raml" />
+    <None Remove="Uses\TestFiles\Test3.raml" />
+    <None Remove="Uses\TestFilesResultExpected\Test3Result.json" />
+    <None Remove="Uses\TestFiles\TestExternalFiles\common-traits2.raml" />
+    <None Remove="Uses\TestFiles\Test2.raml" />
+    <None Remove="Uses\TestFilesResultExpected\Test4Result.json" />
+    <None Remove="Uses\TestFiles\Test4.raml" />
+    <None Remove="Uses\TestFiles\TestExternalFiles\common-traits4-1.raml" />
+    <None Remove="Uses\TestFiles\TestExternalFiles\common-traits4.raml" />
+  </ItemGroup>
+  <ItemGroup>
     <None Update="QueryParameters\QueryParameterRequired.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -66,4 +86,54 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Uses\" />
+    <Folder Include="Uses\TestFiles\" />
+    <Folder Include="Uses\TestFiles\TestExternalFiles\" />
+    <Folder Include="Uses\TestFilesResultExpected\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Uses\TestFiles\Test1.raml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Uses\TestFilesResultExpected\Test1Result.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Uses\TestFiles\TestExternalFiles\common-traits1.raml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Uses\TestFiles\Test2.raml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Uses\TestFilesResultExpected\Test2Result.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Uses\TestFiles\TestExternalFiles\common-traits3.raml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Uses\TestFiles\Test3.raml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Uses\TestFilesResultExpected\Test3Result.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Uses\TestFiles\TestExternalFiles\common-traits2.raml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Uses\TestFiles\Test2.raml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Uses\TestFilesResultExpected\Test4Result.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Uses\TestFiles\Test4.raml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Uses\TestFiles\TestExternalFiles\common-traits4-1.raml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Uses\TestFiles\TestExternalFiles\common-traits4.raml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/test/RamlToOpenApiConverterTest/Uses/TestFiles/Test1.raml
+++ b/test/RamlToOpenApiConverterTest/Uses/TestFiles/Test1.raml
@@ -1,0 +1,21 @@
+#%RAML 1.0
+title: test1
+description: Test1.
+mediaType:
+  - application/json
+version: "v1"
+protocols:
+  - HTTPS
+
+baseUri: /test/raml/1
+
+uses: 
+  uses_traits: TestExternalFiles/common-traits1.raml
+
+/:
+  get: 
+    displayName: "Test1"
+    is: uses_traits.commonHeaders
+    responses:
+      200:
+        description: "Response Success Test 1"

--- a/test/RamlToOpenApiConverterTest/Uses/TestFiles/Test2.raml
+++ b/test/RamlToOpenApiConverterTest/Uses/TestFiles/Test2.raml
@@ -1,0 +1,21 @@
+#%RAML 1.0
+title: test2
+description: Test2.
+mediaType:
+  - application/json
+version: "v1"
+protocols:
+  - HTTPS
+
+baseUri: /test/raml/2
+
+uses: 
+  uses_traits: TestExternalFiles/common-traits2.raml
+
+/:
+  patch: 
+    displayName: "Test2"
+    is: uses_traits.ex2.pagination
+    responses:
+      201:
+        description: "Response Success Test 2"

--- a/test/RamlToOpenApiConverterTest/Uses/TestFiles/Test3.raml
+++ b/test/RamlToOpenApiConverterTest/Uses/TestFiles/Test3.raml
@@ -1,0 +1,16 @@
+#%RAML 1.0
+title: test3
+description: Test3.
+mediaType:
+  - application/json
+version: "v1"
+protocols:
+  - HTTPS
+
+baseUri: /test/raml/3
+
+uses:
+  paths: TestExternalFiles/common-traits3.raml
+  uses_traits: TestExternalFiles/common-traits1.raml
+
+is: paths

--- a/test/RamlToOpenApiConverterTest/Uses/TestFiles/Test4.raml
+++ b/test/RamlToOpenApiConverterTest/Uses/TestFiles/Test4.raml
@@ -1,0 +1,17 @@
+#%RAML 1.0
+title: test3
+description: Test3.
+mediaType:
+  - application/json
+version: "v1"
+protocols:
+  - HTTPS
+
+baseUri: /test/raml/4
+
+uses:
+  paths: TestExternalFiles/common-traits4.raml
+  methods: TestExternalFiles/common-traits4-1.raml
+  uses_traits: TestExternalFiles/common-traits1.raml
+
+is: paths

--- a/test/RamlToOpenApiConverterTest/Uses/TestFiles/Test4.raml
+++ b/test/RamlToOpenApiConverterTest/Uses/TestFiles/Test4.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
-title: test3
-description: Test3.
+title: test4
+description: Test4.
 mediaType:
   - application/json
 version: "v1"

--- a/test/RamlToOpenApiConverterTest/Uses/TestFiles/TestExternalFiles/common-traits1.raml
+++ b/test/RamlToOpenApiConverterTest/Uses/TestFiles/TestExternalFiles/common-traits1.raml
@@ -1,0 +1,34 @@
+#%RAML 1.0 Library
+traits:
+  test-id-required:
+    headers:
+      test_id:
+        type: string
+        required: true
+      test_secret:
+        type: string
+        required: true
+
+  pagination:
+    queryParameters:
+      offset:
+        description: Starting entry number, first entry is 1
+        type: integer
+        required: false
+        example: 1
+      limit:
+        description: Maximum number of entries per page
+        type: integer
+        required: false
+        example: 50
+
+  commonHeaders:
+    headers:
+      X-Correlation-Id: 
+        displayName: Correlation ID
+        type: string
+        required: true
+  
+    
+
+        

--- a/test/RamlToOpenApiConverterTest/Uses/TestFiles/TestExternalFiles/common-traits2.raml
+++ b/test/RamlToOpenApiConverterTest/Uses/TestFiles/TestExternalFiles/common-traits2.raml
@@ -1,0 +1,31 @@
+#%RAML 1.0 Library
+traits:
+  ex2:
+    test-id-required:
+      headers:
+        test_id:
+          type: string
+          required: true
+        test_secret:
+          type: string
+          required: true
+    
+    pagination:
+      queryParameters:
+        offset:
+          description: Starting entry number, first entry is 1
+          type: integer
+          required: false
+          example: 1
+        limit:
+          description: Maximum number of entries per page
+          type: integer
+          required: false
+          example: 50
+    
+    commonHeaders:
+      headers:
+        X-Correlation-Id: 
+          displayName: Correlation ID
+          type: string
+          required: true

--- a/test/RamlToOpenApiConverterTest/Uses/TestFiles/TestExternalFiles/common-traits3.raml
+++ b/test/RamlToOpenApiConverterTest/Uses/TestFiles/TestExternalFiles/common-traits3.raml
@@ -1,0 +1,9 @@
+#%RAML 1.0 Library
+traits:
+  /:
+    post: 
+      displayName: "Test3"
+      is: uses_traits.test-id-required
+      responses:
+        201:
+          description: "Response Success Test 3"

--- a/test/RamlToOpenApiConverterTest/Uses/TestFiles/TestExternalFiles/common-traits4-1.raml
+++ b/test/RamlToOpenApiConverterTest/Uses/TestFiles/TestExternalFiles/common-traits4-1.raml
@@ -1,0 +1,8 @@
+#%RAML 1.0 Library
+traits:
+  post: 
+    displayName: "Test4"
+    is: uses_traits.test-id-required
+    responses:
+      201:
+        description: "Response Success Test 4 Post"

--- a/test/RamlToOpenApiConverterTest/Uses/TestFiles/TestExternalFiles/common-traits4.raml
+++ b/test/RamlToOpenApiConverterTest/Uses/TestFiles/TestExternalFiles/common-traits4.raml
@@ -1,0 +1,17 @@
+#%RAML 1.0 Library
+traits:
+  /path1:
+    is: methods
+  /path2:
+    put: 
+      displayName: "Test4"
+      is: uses_traits.pagination
+      responses:
+        200:
+          description: "Response Success Test 4 Put"
+    get: 
+      displayName: "Test4"
+      is: uses_traits.commonHeaders
+      responses:
+        200:
+          description: "Response Success Test 4 Get"

--- a/test/RamlToOpenApiConverterTest/Uses/TestFilesResultExpected/Test1Result.json
+++ b/test/RamlToOpenApiConverterTest/Uses/TestFilesResultExpected/Test1Result.json
@@ -1,0 +1,34 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "test1",
+    "description": "Test1.",
+    "version": "v1"
+  },
+  "servers": [
+    {
+      "url": "/test/raml/1"
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "parameters": [
+          {
+            "name": "X-Correlation-Id",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response Success Test 1"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/RamlToOpenApiConverterTest/Uses/TestFilesResultExpected/Test2Result.json
+++ b/test/RamlToOpenApiConverterTest/Uses/TestFilesResultExpected/Test2Result.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "test2",
+    "description": "Test2.",
+    "version": "v1"
+  },
+  "servers": [
+    {
+      "url": "/test/raml/2"
+    }
+  ],
+  "paths": {
+    "/": {
+      "patch": {
+        "parameters": [
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Starting entry number, first entry is 1",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of entries per page",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Response Success Test 2"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/RamlToOpenApiConverterTest/Uses/TestFilesResultExpected/Test3Result.json
+++ b/test/RamlToOpenApiConverterTest/Uses/TestFilesResultExpected/Test3Result.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "test3",
+    "description": "Test3.",
+    "version": "v1"
+  },
+  "servers": [
+    {
+      "url": "/test/raml/3"
+    }
+  ],
+  "paths": {
+    "/": {
+      "post": {
+        "parameters": [
+          {
+            "name": "test_id",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "test_secret",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Response Success Test 3"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/RamlToOpenApiConverterTest/Uses/TestFilesResultExpected/Test4Result.json
+++ b/test/RamlToOpenApiConverterTest/Uses/TestFilesResultExpected/Test4Result.json
@@ -1,0 +1,86 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "test3",
+    "description": "Test3.",
+    "version": "v1"
+  },
+  "servers": [
+    {
+      "url": "/test/raml/4"
+    }
+  ],
+  "paths": {
+    "/path2": {
+      "put": {
+        "parameters": [
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Starting entry number, first entry is 1",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of entries per page",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response Success Test 4 Put"
+          }
+        }
+      },
+      "get": {
+        "parameters": [
+          {
+            "name": "X-Correlation-Id",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response Success Test 4 Get"
+          }
+        }
+      }
+    },
+    "/path1": {
+      "post": {
+        "parameters": [
+          {
+            "name": "test_id",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "test_secret",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Response Success Test 4 Post"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/RamlToOpenApiConverterTest/Uses/TestFilesResultExpected/Test4Result.json
+++ b/test/RamlToOpenApiConverterTest/Uses/TestFilesResultExpected/Test4Result.json
@@ -1,8 +1,8 @@
 {
   "openapi": "3.0.1",
   "info": {
-    "title": "test3",
-    "description": "Test3.",
+    "title": "test4",
+    "description": "Test4.",
     "version": "v1"
   },
   "servers": [

--- a/test/RamlToOpenApiConverterTest/Uses/UsesTest.cs
+++ b/test/RamlToOpenApiConverterTest/Uses/UsesTest.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using RamlToOpenApiConverter;
+using RamlToOpenApiConverterTest.Extensions;
+using Xunit;
+namespace RamlToOpenApiConverterTest.Uses
+{
+    public class UsesTest
+    {
+        private readonly RamlConverter _testResult;
+
+        public UsesTest()
+        {
+            _testResult = new RamlConverter();
+        }
+
+        [Theory]
+        [InlineData("Test1")]
+        [InlineData("Test2")]
+        [InlineData("Test3")]
+        [InlineData("Test4")]
+        private void ValidateUsesReplace(string path)
+        {
+            // Arrange
+            string expected = File.ReadAllText(Path.Combine("Uses/TestFilesResultExpected", $"{path}Result.json"));
+
+            // Act
+            string result = _testResult.Convert(Path.Combine("Uses/TestFiles", $"{path}.raml"));
+
+            // Assert
+            result.NormalizeNewLines().Should().BeEquivalentTo(expected.NormalizeNewLines());
+        }
+
+    }
+}


### PR DESCRIPTION
Hi @StefH 

This new feature reads the "Uses"sentence  in the RAML file and replaces them in the "is" sentence.

Example:

This is the external file named _common-traits.raml_ and include a header as parameter.

```
#%RAML 1.0 Library
traits:
  commonHeaders:
    headers:
      X-Correlation-Id: 
        displayName: Correlation ID
        type: string
        required: true
```

This is the parent file that includes the _uses_ declaration (pointing to the external file _common-traits.raml_ ) with its respective _is_ declaration.


```
#%RAML 1.0
title: card-exp
description: This is the experience API for external clients, based on the internal Valley National Bank core banking API.  It contains basic card actions.
mediaType:
  - application/json
version: "v1"
protocols:
  - HTTPS

baseUri: /core/raml/v1/card

types:
  Card: !include datatypes/Card.raml

uses: 
  lib: exchange_modules/bff19d9c-2cca-46b7-863a-341e356ae44c/common-library/1.0.18/common-traits.raml

/:
  post: 
    displayName: "CreateNewCard"
    is: lib.commonHeaders
    body:
      application/json:
        type: Card
        example: !include examples/CreateCardRequest.json
    responses:
      201:
        description: "Response Success"
```

Here is the result obtained:

```

{
  "openapi": "3.0.1",
  "info": {
    "title": "card-exp",
    "description": "This is the experience API for external clients, based on the internal Valley National Bank core banking API.  It contains basic card actions.",
    "version": "v1"
  },
  "servers": [
    {
      "url": "/core/raml/v1/card"
    }
  ],
  "paths": {
    "/": {
      "post": {
        "description": "CreateNewCard",
        "parameters": [
          {
            "name": "X-Correlation-Id",
            "in": "header",
            "required": true,
            "schema": {
              "type": "string"
            }
          }
        ],
        "requestBody": {
          "content": {
            "application/json": {
              "schema": {
                "$ref": "#/components/schemas/Card"
              },
              "example": {
                "productType": "DEBIT",
                "accountNumber": "0314453822",
                "accountSuffix": "10",
                "customerId": "000040315476",
                "custType": "C"
              }
            }
          }
        },
        "responses": {
          "201": {
            "description": "Response Success"
          }
        }
      }
    }
  },
  "components": {
    "schemas": {
      "Card": {
        "type": "object",
        "properties": {
          "productType": {
            "type": "ProductType"
          },
          "accountNumber": {
            "type": "string"
          },
          "accountSuffix": {
            "type": "string"
          },
          "customerId": {
            "type": "string"
          },
          "cardClass?": {
            "type": "integer"
          },
          "prodCode1?": {
            "type": "integer"
          },
          "applCode1?": {
            "type": "integer"
          },
          "panNumber?": {
            "type": "string"
          },
          "expirationDate?": {
            "type": "string"
          },
          "transactionId?": {
            "type": "string"
          },
          "custType?": {
            "enum": [
              "P",
              "C"
            ],
            "type": "string"
          }
        }
      }
    }
  }
}
```

References:

[Modular RAML](https://www.baeldung.com/modular-raml-includes-overlays-libraries-extensions)





